### PR TITLE
Fix IE append error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f-twelve",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Render console output to the DOM and provide an input console for troubleshooting environments that do not have the usual F12 dev console.",
   "main": "lib/main.js",
   "scripts": {

--- a/src/utilities/jsx.js
+++ b/src/utilities/jsx.js
@@ -51,8 +51,8 @@ const append = (parent, child) => {
   if (Array.isArray(child)) {
     child.forEach(grandChild => append(parent, grandChild));
   } else if (typeof child === 'string') {
-    parent.append(document.createTextNode(child));
+    parent.appendChild(document.createTextNode(child));
   } else {
-    parent.append(child);
+    parent.appendChild(child);
   }
 };


### PR DESCRIPTION
Use appendchild to fix ie error: `Object doesn't support property or method 'append'` 